### PR TITLE
Upgrade cedar 14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source :rubygems
+source 'https://rubygems.org'
+
+ruby '1.9.3'
 
 gem "middleman", "~>3.0.7"
 gem "tzinfo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.11)
       i18n (~> 0.6)
@@ -138,3 +138,6 @@ DEPENDENCIES
   redcarpet
   tzinfo
   zazz
+
+BUNDLED WITH
+   1.10.3

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,4 @@
+require 'rubygems'
+require 'middleman/rack'
+
+run Middleman.server


### PR DESCRIPTION
The current version of HoH will not deploy on Heroku's cedar-14 stack.  I've made some small tweaks to enable this workflow.