### PR TITLE
use the mainline ruby buildpack and the static buildpack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+task "assets:precompile" do
+  puts `bundle exec middleman build 2>&1`
+end

--- a/static.json
+++ b/static.json
@@ -1,0 +1,4 @@
+{
+  "root": "build",
+  "clean_urls": false
+}


### PR DESCRIPTION
This makes it possible to use the heroku ruby buildpack to build your assets and then the [static buildpack](https://github.com/hone/heroku-buildpack-static) to serve the build stuff. To setup the buildpacks, use the new buildpacks command:

```sh
$ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-ruby
$ heroku buildpacks:add https://github.com/hone/heroku-buildpack-static
```